### PR TITLE
Inherit from StandardError

### DIFF
--- a/lib/mandrill/errors.rb
+++ b/lib/mandrill/errors.rb
@@ -1,5 +1,5 @@
 module Mandrill
-    class Error < Exception
+    class Error < StandardError
     end
     class ValidationError < Error
     end


### PR DESCRIPTION
Bad things™️ happen when the Mandrill errors inherit from `Exception` - most server code will gracefully handle `StandardError`.